### PR TITLE
Support Heroku deployment out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@ npm start
 * Go to [http://localhost:3000](http://localhost:3000) to see the site.
 
 
+## Deploying to Heroku
+
+The database migration doesn't run automatically in `postinstall` on production builds, so you'll need to invoke it manually. Always a good idea to make sure you don't accidentally nuke your production database!
+
+```shell
+heroku login
+heroku create
+heroku addons:create heroku-postgresql:hobby-dev
+heroku run npm run migrate:prod
+```
+
 ## More information
 
 The session and JWT secrets are loaded from environment variables.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "nodemon --watch server & webpack --watch",
     "knex": "knex",
-    "postinstall": "knex migrate:latest && webpack",
+    "migrate": "[ \"$NODE_ENV\" = \"production\" ] && exit 0; knex migrate:latest",
+    "migrate:prod": "knex migrate:latest",
+    "postinstall": "webpack && npm run migrate",
     "start": "node server",
     "test": "ava",
     "test:watch": "ava --watch"
@@ -39,6 +41,7 @@
     "knex": "^0.12.6",
     "passport": "^0.3.2",
     "passport-local": "^1.0.0",
+    "pg": "^7.2.0",
     "react": "^15.3.0",
     "react-dom": "^15.3.0",
     "react-redux": "^4.4.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,26 +1,2 @@
-const path = require('path')
-const LiveReloadPlugin = require('webpack-livereload-plugin')
-
-module.exports = {
-  entry: './client/index.js',
-  output: {
-    filename: 'bundle.js',
-    path: path.join(__dirname, 'public')
-  },
-  module: {
-    loaders: [
-      {
-        loader: 'babel-loader',
-        test: /\.jsx?$/,
-        exclude: path.join(__dirname, 'node_modules')
-      }
-    ]
-  },
-  resolve: {
-    extensions: ['.js', '.jsx']
-  },
-  plugins: [
-    new LiveReloadPlugin()
-  ],
-  devtool: 'source-map'
-}
+const env = process.env.NODE_ENV || 'development'
+module.exports = require(`./webpack.${env}.js`)

--- a/webpack.development.js
+++ b/webpack.development.js
@@ -1,0 +1,26 @@
+const path = require('path')
+const LiveReloadPlugin = require('webpack-livereload-plugin')
+
+module.exports = {
+  entry: './client/index.js',
+  output: {
+    filename: 'bundle.js',
+    path: path.join(__dirname, 'public')
+  },
+  module: {
+    loaders: [
+      {
+        loader: 'babel-loader',
+        test: /\.jsx?$/,
+        exclude: path.join(__dirname, 'node_modules')
+      }
+    ]
+  },
+  resolve: {
+    extensions: ['.js', '.jsx']
+  },
+  plugins: [
+    new LiveReloadPlugin()
+  ],
+  devtool: 'source-map'
+}

--- a/webpack.production.js
+++ b/webpack.production.js
@@ -1,0 +1,21 @@
+const path = require('path')
+
+module.exports = {
+  entry: './client/index.js',
+  output: {
+    filename: 'bundle.js',
+    path: path.join(__dirname, 'public')
+  },
+  module: {
+    loaders: [
+      {
+        loader: 'babel-loader',
+        test: /\.jsx?$/,
+        exclude: path.join(__dirname, 'node_modules')
+      }
+    ]
+  },
+  resolve: {
+    extensions: ['.js', '.jsx']
+  }
+}


### PR DESCRIPTION
This:

 - [x] chooses a Webpack config based on `NODE_ENV`
 - [x] adds `pg` as a production dependency
 - [x] prevents `migrate:latest` from being run in `postinstall` in a prod environment

Caveat: unlikely to work in an environment that doesn't provide `sh`.